### PR TITLE
feat: Add api for recommended recipes

### DIFF
--- a/backend/webserver/controller/api.js
+++ b/backend/webserver/controller/api.js
@@ -18,4 +18,13 @@ router.post('/logout', fctl.loginRequiredWrapper(async (req, res, next) => {
     return fctl.send(req, res, hsc.HTTP_OK, null);
 }));
 
+router.post('/recommend', async (req, res)=>{
+    try{
+        data = await service.recommendRecipes(req.body.userIngredients);
+        return fctl.send(req, res, hsc.HTTP_OK, data);
+    } catch (error){
+        return fctl.send(req, res, hsc.HTTP_INTERNAL_SERVER_ERROR, {"message": error});
+    }
+});
+
 module.exports = router;

--- a/backend/webserver/controller/api.js
+++ b/backend/webserver/controller/api.js
@@ -18,13 +18,9 @@ router.post('/logout', fctl.loginRequiredWrapper(async (req, res, next) => {
     return fctl.send(req, res, hsc.HTTP_OK, null);
 }));
 
-router.post('/recommend', async (req, res)=>{
-    try{
-        data = await service.recommendRecipes(req.body.userIngredients);
-        return fctl.send(req, res, hsc.HTTP_OK, data);
-    } catch (error){
-        return fctl.send(req, res, hsc.HTTP_INTERNAL_SERVER_ERROR, {"message": error});
-    }
-});
+router.post('/recommend', fctl.nonLoginWrapper(async (req, res, next) => {
+    data = await service.recommendRecipes(req.body.userIngredients);
+    return fctl.send(req, res, hsc.HTTP_OK, data);
+}));
 
 module.exports = router;

--- a/backend/webserver/dao/recipes.js
+++ b/backend/webserver/dao/recipes.js
@@ -1,0 +1,13 @@
+class Recipes {}
+
+require('../utils/dbconnector')(Recipes);
+
+Recipes.getRecipes = async (recipeIds) => {
+    const [row, fields] = await Recipes.db.execute("SELECT * FROM recipes WHERE id IN ("+recipeIds+")");
+    if (row.length === 0) {
+        return null;
+    }
+    return {'result': row};
+}
+
+module.exports = Recipes;

--- a/backend/webserver/dao/recipes.js
+++ b/backend/webserver/dao/recipes.js
@@ -3,11 +3,9 @@ class Recipes {}
 require('../utils/dbconnector')(Recipes);
 
 Recipes.getRecipes = async (recipeIds) => {
-    const [row, fields] = await Recipes.db.execute("SELECT * FROM recipes WHERE id IN ("+recipeIds+")");
-    if (row.length === 0) {
-        return null;
-    }
-    return {'result': row};
+    const [row, fields] = await Recipes.db.execute("SELECT * FROM recipes WHERE FIND_IN_SET(id, ?)", [recipeIds]);
+
+    return {'result': row}; // 검색 결과가 없을 경우 row 는 빈 리스트 []
 }
 
 module.exports = Recipes;

--- a/backend/webserver/service/service.js
+++ b/backend/webserver/service/service.js
@@ -1,4 +1,5 @@
 const users = require('../dao/users.js');
+const recipes = require('../dao/recipes.js');
 const APIError = require('../exceptions/apierror.js');
 const sc = require('../enums/httpstatuscode.js');
 
@@ -10,6 +11,19 @@ Service.getUser = async (userId, password) => {
         throw new APIError(sc.HTTP_UNAUTHORIZED, '잘못된 userId 또는 password 이거나 존재하지않는 사용자입니다');
     }
     return userFound;
+}
+
+Service.recommendRecipes = async (userIngredients) => {
+    console.log(userIngredients);
+    // 파이썬 서버 연결 -> 레시피 아이디 반환
+    const recipeIds = '24,25,26,27';
+
+    // 레시피 아이디로 다시 db 검색
+    const recipesFound = await recipes.getRecipes(recipeIds);
+    if (recipesFound == null){
+        throw new APIError(sc.HTTP_BAD_REQUEST, '레시피를 찾을 수 없습니다.')
+    }
+    return recipesFound;
 }
 
 Object.freeze(Service);


### PR DESCRIPTION
올려주신 코드 참고해서 추천레시피를 가져오는 api 를 작성해보았습니다.
확인 후 수정해야할 부분 있으면 코멘트 남겨주세요!

POST /api/recommend/ 로 유저 재료 리스트를 보낼 때 레시피 리스트를 반환합니다.
Service.recommendRecipes 가 파이썬 서버에 요청해서 추천 레시피 아이디를 가져오는 것으로 설계했는데,
이 방법이 맞는지는 잘 모르겠습니다.

또 /controller/api.js 에 /recommend 로 가는 요청은 아직 fctl 의 사용자 인증 함수로 감싸지는 않았습니다.
저 혼자 테스트 하려고 그런건데 바꿔야한다면 바꾸겠습니다.